### PR TITLE
chore: update version to 0.1.4 and add test utils installation docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Cajun is available on Maven Central. Add it to your project using Gradle:
 
 ```gradle
 dependencies {
-    implementation 'com.cajunsystems:cajun:0.1.3'
+    implementation 'com.cajunsystems:cajun:0.1.4'
 }
 ```
 
@@ -122,7 +122,7 @@ Or with Maven:
 <dependency>
     <groupId>com.cajunsystems</groupId>
     <artifactId>cajun</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
 </dependency>
 ```
 

--- a/test-utils/README.md
+++ b/test-utils/README.md
@@ -14,6 +14,29 @@ The Cajun test utilities eliminate common pain points in actor testing:
 - ✅ **Fast test execution** - Minimal waiting, maximum efficiency
 - ✅ **Complete visibility** - Inspect state, mailbox, and messages
 
+## Installation
+
+Add the test utilities to your project's test dependencies:
+
+**Gradle:**
+```gradle
+dependencies {
+    testImplementation 'com.cajunsystems:cajun-test:0.1.4'
+}
+```
+
+**Maven:**
+```xml
+<dependency>
+    <groupId>com.cajunsystems</groupId>
+    <artifactId>cajun-test</artifactId>
+    <version>0.1.4</version>
+    <scope>test</scope>
+</dependency>
+```
+
+**Note**: The test utilities require Java 21+ with preview features enabled (same as the core Cajun library).
+
 ## Quick Example
 
 ### Before (Without Test Utils)


### PR DESCRIPTION
- Updated version number from 0.1.3 to 0.1.4 in main README.md for both Gradle and Maven examples
- Added new installation section to test-utils/README.md with Gradle and Maven dependency configurations
- Added note about Java 21+ requirement for test utilities